### PR TITLE
Fix _float_connection_matrix silently overwriting values for multi-synapse connections

### DIFF
--- a/brian2tools/plotting/synapses.py
+++ b/brian2tools/plotting/synapses.py
@@ -51,6 +51,9 @@ def _float_connection_matrix(sources, targets, values):
     weights, delays, ...) in the form of a masked matrix (entries without value
     are set to NaN and masked).
 
+    For source-target pairs with multiple synapses the displayed value is the
+    mean across all synapses between that pair.
+
     Parameters
     ----------
     sources : ndarray of int
@@ -65,9 +68,18 @@ def _float_connection_matrix(sources, targets, values):
     matrix : ma.MaskedArray
         The connection matrix, masked for NaN values
     '''
-    full_matrix = np.ones((np.max(targets) - np.min(targets) + 1,
-                           np.max(sources) - np.min(sources) + 1)) * np.nan
-    full_matrix[targets - np.min(targets), sources - np.min(sources)] = values
+    row = targets - np.min(targets)
+    col = sources - np.min(sources)
+    shape = (np.max(targets) - np.min(targets) + 1,
+             np.max(sources) - np.min(sources) + 1)
+    # accumulate values and counts separately to compute the mean, avoiding
+    # the silent last-value-wins overwrite that plain fancy indexing produces
+    # for multi-synaptic connections
+    sum_matrix = np.zeros(shape)
+    count_matrix = np.zeros(shape)
+    np.add.at(sum_matrix, (row, col), values)
+    np.add.at(count_matrix, (row, col), 1)
+    full_matrix = np.where(count_matrix > 0, sum_matrix / count_matrix, np.nan)
     masked_matrix = ma.masked_invalid(full_matrix, copy=False)
     return masked_matrix
 


### PR DESCRIPTION
 I was looking through the plotting utilities and found a bug in _float_connection_matrix that silently produces wrong output for networks with multiple synapses between the same source-target pair.                                                                                                                               
                                                                                                                                                                       
The original code does a plain NumPy fancy index assignment:     
```                                                                                                                                                                                                                                                                       
  full_matrix[targets - np.min(targets), sources - np.min(sources)] = values                                                                                         
```                                                                                                                                                                       
When you have multi-synaptic connections, multiple entries in sources and targets point to the same matrix cell. NumPy just overwrites each time, so only the last   synapse's value survives. If you had two synapses between neuron 0 and neuron 1 with weights 0.3 and 0.7, the matrix would show 0.7 and the 0.3 is gone with no warning.                                                                                                                                                           

  I fixed it by replacing the assignment with two np.add.at accumulations one summing the values, one counting how many synapses hit each cell then dividing to get the mean. Mean makes sense here because the matrix is displaying a synaptic property like weight or delay per connection pair, so the average across al   synapses between that pair is the meaningful thing to show.                                                                                                        
                                                                                                                                                                     
  I also updated the docstring to mention that multi-synaptic pairs display the mean, so users know what they're looking at.                                            